### PR TITLE
add path to mock client ListFiles()

### DIFF
--- a/mock_client.go
+++ b/mock_client.go
@@ -76,7 +76,8 @@ func (c *mockClient) ListFiles(dir string) ([]string, error) {
 	}
 	var out []string
 	for i := range fds {
-		out = append(out, strings.TrimPrefix(fds[i].Name(), c.root))
+		fd := filepath.Join(dir, strings.TrimPrefix(fds[i].Name(), c.root))
+		out = append(out, fd)
 	}
 	return out, nil
 }

--- a/mock_client_test.go
+++ b/mock_client_test.go
@@ -5,6 +5,7 @@
 package go_sftp_test
 
 import (
+	"io"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -32,5 +33,28 @@ func TestMockClient(t *testing.T) {
 	paths, err := client.ListFiles("/")
 	require.NoError(t, err)
 	require.Len(t, paths, 1)
-	require.Equal(t, "exists.txt", paths[0])
+	require.Equal(t, "/exists.txt", paths[0])
+}
+
+func TestMockClient_ListAndOpenFiles(t *testing.T) {
+	client := sftp.NewMockClient()
+	require.NoError(t, client.Ping())
+	defer require.NoError(t, client.Close())
+
+	require.NoError(t, client.UploadFile("/path/f1.txt", ioutil.NopCloser(strings.NewReader("foo"))))
+	require.NoError(t, client.UploadFile("/path/f2.txt", ioutil.NopCloser(strings.NewReader("foo"))))
+
+	foundFiles, err := client.ListFiles("/path/")
+	require.NoError(t, err)
+	require.Len(t, foundFiles, 2)
+
+	for _, file := range foundFiles {
+		found, err := client.Open(file)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+
+		contents, err := io.ReadAll(found.Contents)
+		require.NoError(t, err)
+		require.Equal(t, "foo", string(contents))
+	}
 }


### PR DESCRIPTION
When the production client is used to ListFiles() the results all include the file path that was passed in. The mock client currently only includes the file name without the directory. 