### PR TITLE
revert: undo File's support for fs.File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.6.0 (Released 2022-02-04)
+
+BREAKING CHANGES
+
+- feat: our File type no longer implements the fs.File interface
+
 ## v0.5.2 (Released 2022-01-31)
 
 BUG FIXES

--- a/client.go
+++ b/client.go
@@ -413,7 +413,6 @@ func (c *client) Open(path string) (*File, error) {
 	}
 
 	return &File{
-		fd:       fd,
 		Filename: fd.Name(),
 		Contents: ioutil.NopCloser(&buf),
 	}, nil

--- a/file.go
+++ b/file.go
@@ -5,46 +5,20 @@
 package go_sftp
 
 import (
-	"errors"
 	"io"
-	"io/fs"
-	"os"
-
-	"github.com/pkg/sftp"
 )
 
 type File struct {
-	fd *sftp.File
-
 	Filename string
 	Contents io.ReadCloser
 }
 
-func (f *File) Read(b []byte) (int, error) {
-	if f == nil {
-		return 0, io.EOF
-	}
-	if f.fd == nil {
-		return f.Contents.Read(b)
-	}
-	return f.fd.Read(b)
-}
-
-func (f *File) Stat() (os.FileInfo, error) {
-	if f == nil || f.fd == nil {
-		return nil, errors.New("nil File")
-	}
-	return f.fd.Stat()
-}
-
 func (f *File) Close() error {
-	if f.Contents != nil {
-		f.Contents.Close()
+	if f == nil {
+		return nil
 	}
-	if f.fd != nil {
-		return f.fd.Close()
+	if f.Contents != nil {
+		return f.Contents.Close()
 	}
 	return nil
 }
-
-var _ fs.File = (&File{})


### PR DESCRIPTION
This is causing headaches and isn't really needed. 