### PR TITLE
fix: make PacketSize optional in our config

### DIFF
--- a/client.go
+++ b/client.go
@@ -121,8 +121,11 @@ func (c *client) connection() (*sftp.Client, error) {
 	// Setup our SFTP client
 	var opts = []sftp.ClientOption{
 		sftp.MaxConcurrentRequestsPerFile(c.cfg.MaxConnections),
-		sftp.MaxPacket(c.cfg.PacketSize),
 	}
+	if c.cfg.PacketSize > 0 {
+		opts = append(opts, sftp.MaxPacket(c.cfg.PacketSize))
+	}
+
 	// client, err := sftp.NewClient(conn, opts...)
 	client, err := sftp.NewClientPipe(stdout, stdin, opts...)
 	if err != nil {


### PR DESCRIPTION
[github.com/pkg/sftp](https://github.com/pkg/sftp/blob/v1.13.4/client.go#L83) defaults this to 32768 bytes and our client offers an override however this value is currently required. We don't need to require this.