### PR TITLE
Log found file names

### DIFF
--- a/client.go
+++ b/client.go
@@ -371,7 +371,7 @@ func (c *client) ListFiles(dir string) ([]string, error) {
 		filenames = append(filenames, filepath.Join(dir, info.Name()))
 	}
 
-	c.logger.Logf("found %d files: %s", len(infos), fileInfoString(filenames))
+	c.logger.Logf("found %d files: %s", len(infos), strings.Join(filenames, ", "))
 
 	return filenames, nil
 }
@@ -412,15 +412,4 @@ func (c *client) Open(path string) (*File, error) {
 		Contents: ioutil.NopCloser(&buf),
 		ModTime:  modTime,
 	}, nil
-}
-
-func fileInfoString(infos []string) string {
-	result := ""
-	for i, info := range infos {
-		if i > 0 {
-			result += ", "
-		}
-		result += info
-	}
-	return result
 }

--- a/client.go
+++ b/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-kit/kit/metrics/prometheus"
 	"github.com/pkg/sftp"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
+
 	"golang.org/x/crypto/ssh"
 )
 
@@ -361,8 +362,6 @@ func (c *client) ListFiles(dir string) ([]string, error) {
 		return nil, fmt.Errorf("sftp: readdir %s: %v", dir, err)
 	}
 
-	c.logger.Logf("found %d files: %#v", len(infos), infos)
-
 	var filenames []string
 	for _, info := range infos {
 		if info.IsDir() {
@@ -371,6 +370,9 @@ func (c *client) ListFiles(dir string) ([]string, error) {
 
 		filenames = append(filenames, filepath.Join(dir, info.Name()))
 	}
+
+	c.logger.Logf("found %d files: %s", len(infos), fileInfoString(filenames))
+
 	return filenames, nil
 }
 
@@ -410,4 +412,15 @@ func (c *client) Open(path string) (*File, error) {
 		Contents: ioutil.NopCloser(&buf),
 		ModTime:  modTime,
 	}, nil
+}
+
+func fileInfoString(infos []string) string {
+	result := ""
+	for i, info := range infos {
+		if i > 0 {
+			result += ", "
+		}
+		result += info
+	}
+	return result
 }


### PR DESCRIPTION
Update log message to output list of file names rather than pointer addresses.

Example bad log:
```
msg=“found 19 files: []fs.FileInfo{(*sftp.fileInfo)(0xc000302330), (*sftp.fileInfo)(0xc000302348), (*sftp.fileInfo)(0xc000302378), (*sftp.fileInfo)(0xc000302390), (*sftp.fileInfo)(0xc0003023a8), (*sftp.fileInfo)(0xc0003023c0), (*sftp.fileInfo)(0xc0003023f0), (*sftp.fileInfo)(0xc000302420), (*sftp.fileInfo)(0xc000302438), (*sftp.fileInfo)(0xc000302450), (*sftp.fileInfo)(0xc000302468), (*sftp.fileInfo)(0xc000302480), (*sftp.fileInfo)(0xc000302498), (*sftp.fileInfo)(0xc0003024b0), (*sftp.fileInfo)(0xc0003024c8), (*sftp.fileInfo)(0xc0003024f8), (*sftp.fileInfo)(0xc000302510), (*sftp.fileInfo)(0xc000302540), (*sftp.fileInfo)(0xc000302558)}”
```