### PR TITLE
feat: add Walk function for traversing a directory

### DIFF
--- a/client.go
+++ b/client.go
@@ -349,6 +349,7 @@ func (c *client) UploadFile(path string, contents io.ReadCloser) error {
 	return nil
 }
 
+// ListFiles will return the filepaths of files within dir
 func (c *client) ListFiles(dir string) ([]string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -377,6 +378,7 @@ func (c *client) ListFiles(dir string) ([]string, error) {
 	return filenames, nil
 }
 
+// Open will return the contents at path
 func (c *client) Open(path string) (*File, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -415,6 +417,9 @@ func (c *client) Open(path string) (*File, error) {
 	}, nil
 }
 
+// Walk will traverse dir and call fs.WalkDirFunc on each entry.
+//
+// Follow the docs for fs.WalkDirFunc for details on traversal. Walk accepts fs.SkipDir to not process directories.
 func (c *client) Walk(dir string, fn fs.WalkDirFunc) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/mock_client.go
+++ b/mock_client.go
@@ -6,6 +6,7 @@ package go_sftp
 
 import (
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -87,4 +88,18 @@ func (c *MockClient) ListFiles(dir string) ([]string, error) {
 		out = append(out, fd)
 	}
 	return out, nil
+}
+
+func (c *MockClient) Walk(dir string, fn fs.WalkDirFunc) error {
+	if c.Err != nil {
+		return c.Err
+	}
+
+	d, err := filepath.Abs(filepath.Join(c.root, dir))
+	if err != nil {
+		return err
+	}
+	os.MkdirAll(d, 0777)
+
+	return fs.WalkDir(os.DirFS(d), ".", fn)
 }

--- a/mock_client.go
+++ b/mock_client.go
@@ -19,6 +19,8 @@ type MockClient struct {
 	Err error
 }
 
+var _ Client = (&MockClient{})
+
 func NewMockClient(t *testing.T) *MockClient {
 	return &MockClient{
 		root: t.TempDir(),

--- a/mock_client_test.go
+++ b/mock_client_test.go
@@ -7,6 +7,7 @@ package go_sftp_test
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -64,4 +65,16 @@ func TestMockClient_ListAndOpenFiles(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "foo", string(contents))
 	}
+
+	// Walk the directory and list files
+	var walkedFiles []string
+	err = client.Walk("/path/", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		walkedFiles = append(walkedFiles, path)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Contains(t, walkedFiles, "f1.txt", "f2.txt")
 }


### PR DESCRIPTION
This is an enhancement to ListFiles() where a lot of memory can be wasted with Open() calls since Open() reads the file.