### PR TITLE
feat: add Reader() method to clients for streaming contents

### DIFF
--- a/mock_client.go
+++ b/mock_client.go
@@ -39,6 +39,10 @@ func (c *MockClient) Close() error {
 	return c.Err
 }
 
+func (c *MockClient) Reader(path string) (*File, error) {
+	return c.Open(path)
+}
+
 func (c *MockClient) Open(path string) (*File, error) {
 	if c.Err != nil {
 		return nil, c.Err

--- a/mock_client_test.go
+++ b/mock_client_test.go
@@ -64,6 +64,17 @@ func TestMockClient_ListAndOpenFiles(t *testing.T) {
 		contents, err := io.ReadAll(found.Contents)
 		require.NoError(t, err)
 		require.Equal(t, "foo", string(contents))
+		require.NoError(t, found.Close())
+
+		// Consume the file with Reader
+		found, err = client.Reader(file)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+
+		contents, err = io.ReadAll(found.Contents)
+		require.NoError(t, err)
+		require.Equal(t, "foo", string(contents))
+		require.NoError(t, found.Close())
 	}
 
 	// Walk the directory and list files


### PR DESCRIPTION
Instead of consuming the entire file we can offer an io.ReadCloser to callers.