### PR TITLE
fix: if conn.Stat returns no file Delete is successful

### DIFF
--- a/client.go
+++ b/client.go
@@ -338,10 +338,16 @@ func (c *client) Delete(path string) error {
 	}
 
 	info, err := conn.Stat(path)
-	err = c.clearConnectionOnError(err)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // file doesn't exist
+		}
+
+		// The error is something else related to STAT so return that
+		err = c.clearConnectionOnError(err)
 		return fmt.Errorf("sftp: delete stat: %w", err)
 	}
+
 	if info != nil {
 		err := conn.Remove(path)
 		err = c.clearConnectionOnError(err)
@@ -349,6 +355,7 @@ func (c *client) Delete(path string) error {
 			return fmt.Errorf("sftp: delete: %w", err)
 		}
 	}
+
 	return nil // not found
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -255,6 +255,14 @@ func TestClient(t *testing.T) {
 		require.NoError(t, file.Close())
 	})
 
+	t.Run("Delete", func(t *testing.T) {
+		err := client.Delete("/missing.txt")
+		require.NoError(t, err)
+
+		err = client.Delete("/no-existing-dir/missing.txt")
+		require.NoError(t, err)
+	})
+
 	t.Run("Skip chmod after upload", func(t *testing.T) {
 		// upload file
 		fileName := fmt.Sprintf("/upload/%d.txt", time.Now().Unix())


### PR DESCRIPTION
We can check this earlier from `conn.Stat` which returns the standard Go errors. 