### PR TITLE
Add configuration option: SkipSyncAfterUpload

### DIFF
--- a/client.go
+++ b/client.go
@@ -384,12 +384,14 @@ func (c *client) UploadFile(path string, contents io.ReadCloser) error {
 		return fmt.Errorf("sftp: problem copying (n=%d) %s: %w", n, path, err)
 	}
 
-	err = fd.Sync()
-	err = c.clearConnectionOnError(err)
-	if err != nil {
-		// Skip sync if the remote server doesn't support it
-		if !strings.Contains(err.Error(), "SSH_FX_OP_UNSUPPORTED") {
-			return fmt.Errorf("sftp: problem with sync on %s: %v", path, err)
+	if !c.cfg.SkipSyncAfterUpload {
+		err = fd.Sync()
+		err = c.clearConnectionOnError(err)
+		if err != nil {
+			// Skip sync if the remote server doesn't support it
+			if !strings.Contains(err.Error(), "SSH_FX_OP_UNSUPPORTED") {
+				return fmt.Errorf("sftp: problem with sync on %s: %v", path, err)
+			}
 		}
 	}
 

--- a/client_config.go
+++ b/client_config.go
@@ -26,6 +26,7 @@ type ClientConfig struct {
 
 	SkipChmodAfterUpload  bool
 	SkipDirectoryCreation bool
+	SkipSyncAfterUpload   bool
 }
 
 // HostKeys returns the list of configured public keys to use for host key verification.


### PR DESCRIPTION
Some SFTP servers will rename/remove files after upload or have you upload them to a write-only location. This will result in a file not found error if you try to sync afterwards.