### PR TITLE
fix: require SFTP host key validation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+BREAKING CHANGES
+
+- Require `HostPublicKey(s)` for SFTP connections. The previous insecure default of skipping host key validation has been removed. Callers that intentionally skip verification must set `InsecureIgnoreHostKey: true` (tests/trusted networks only).
+
+IMPROVEMENTS
+
+- Fix CodeQL `go/insecure-hostkeycallback` by failing closed unless host keys are configured or insecure mode is explicitly enabled
+
 ## v0.16.0 (Released 2025-03-28)
 
 ADDITIONS

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ type Client interface {
 }
 ```
 
+Configuration requires at least one of `HostPublicKey` / `HostPublicKeys` so the remote server identity is verified. For local tests only, set `InsecureIgnoreHostKey: true`.
+
 The library also includes a [mock client implementation](https://pkg.go.dev/github.com/moov-io/go-sftp#MockClient) which uses a local filesystem temporary directory for testing.
 
 ## Project status

--- a/client.go
+++ b/client.go
@@ -163,16 +163,6 @@ func (c *client) clearConnectionOnError(err error) error {
 	return err
 }
 
-var (
-	hostKeyCallbackOnce sync.Once
-	hostKeyCallback     = func(logger log.Logger) {
-		msg := "sftp: WARNING!!! Insecure default of skipping SFTP host key validation. Please set HostPublicKey(s)"
-		if logger != nil {
-			logger.Warn().Log(msg)
-		}
-	}
-)
-
 func sftpConnect(logger log.Logger, cfg ClientConfig) (*ssh.Client, io.WriteCloser, io.Reader, error) {
 	conf := &ssh.ClientConfig{
 		User:    cfg.Username,
@@ -186,12 +176,18 @@ func sftpConnect(logger log.Logger, cfg ClientConfig) (*ssh.Client, io.WriteClos
 			return nil, nil, nil, err
 		}
 		conf.HostKeyCallback = callback
-	} else {
-		hostKeyCallbackOnce.Do(func() {
-			hostKeyCallback(logger)
-		})
+	} else if cfg.InsecureIgnoreHostKey {
+		if logger != nil {
+			logger.Warn().Log("sftp: InsecureIgnoreHostKey enabled; remote host key will not be validated")
+		}
+		// Intentionally insecure and only reachable when callers opt in.
+		// Prefer HostPublicKeys in production.
+		//
+		// codeql[go/insecure-hostkeycallback] caller-opted-in insecure host key validation
 		//nolint:gosec
-		conf.HostKeyCallback = ssh.InsecureIgnoreHostKey() // insecure default
+		conf.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+	} else {
+		return nil, nil, nil, errors.New("sftp: HostPublicKey(s) are required (set InsecureIgnoreHostKey to skip validation in tests)")
 	}
 	// Setup various Authentication methods
 	if cfg.Password != "" {

--- a/client_config.go
+++ b/client_config.go
@@ -18,7 +18,13 @@ type ClientConfig struct {
 
 	// HostPublicKeys configures multiple SSH public keys to validate the remote server's host key.
 	// Any key provided in HostPublicKey will be appended to this list.
+	// At least one host key is required unless InsecureIgnoreHostKey is true.
 	HostPublicKeys []string
+
+	// InsecureIgnoreHostKey skips remote host key verification when no HostPublicKeys
+	// are configured. This is vulnerable to machine-in-the-middle attacks and should
+	// only be used in tests or fully trusted networks. Prefer HostPublicKeys.
+	InsecureIgnoreHostKey bool
 
 	// ClientPrivateKey must be a base64 encoded string
 	ClientPrivateKey         string

--- a/client_test.go
+++ b/client_test.go
@@ -34,6 +34,15 @@ func TestClientErr(t *testing.T) {
 		MaxConnections: 0,
 		PacketSize:     0,
 	})
+	require.ErrorContains(t, err, "HostPublicKey")
+
+	_, err = sftp.NewClient(log.NewTestLogger(), &sftp.ClientConfig{
+		Hostname:              "localhost:invalid",
+		Timeout:               0 * time.Second,
+		MaxConnections:        0,
+		PacketSize:            0,
+		InsecureIgnoreHostKey: true,
+	})
 	require.Error(t, err)
 }
 
@@ -43,12 +52,13 @@ func TestClient(t *testing.T) {
 	}
 
 	client, err := sftp.NewClient(log.NewTestLogger(), &sftp.ClientConfig{
-		Hostname:       "localhost:2222",
-		Username:       "demo",
-		Password:       "password",
-		Timeout:        5 * time.Second,
-		MaxConnections: 1,
-		PacketSize:     32000,
+		Hostname:              "localhost:2222",
+		Username:              "demo",
+		Password:              "password",
+		Timeout:               5 * time.Second,
+		MaxConnections:        1,
+		PacketSize:            32000,
+		InsecureIgnoreHostKey: true,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -307,12 +317,13 @@ func TestClient__UploadFile(t *testing.T) {
 	}
 
 	conf := &sftp.ClientConfig{
-		Hostname:       "localhost:2222",
-		Username:       "demo",
-		Password:       "password",
-		Timeout:        5 * time.Second,
-		MaxConnections: 1,
-		PacketSize:     32000,
+		Hostname:              "localhost:2222",
+		Username:              "demo",
+		Password:              "password",
+		Timeout:               5 * time.Second,
+		MaxConnections:        1,
+		PacketSize:            32000,
+		InsecureIgnoreHostKey: true,
 	}
 
 	subdir := strconv.FormatInt(time.Now().UnixMilli(), 10)

--- a/network_test.go
+++ b/network_test.go
@@ -19,12 +19,13 @@ func TestNetwork(t *testing.T) {
 	}
 
 	client, err := sftp.NewClient(log.NewTestLogger(), &sftp.ClientConfig{
-		Hostname:       "localhost:2222",
-		Username:       "demo",
-		Password:       "password",
-		Timeout:        5 * time.Second,
-		MaxConnections: 1,
-		PacketSize:     32000,
+		Hostname:              "localhost:2222",
+		Username:              "demo",
+		Password:              "password",
+		Timeout:               5 * time.Second,
+		MaxConnections:        1,
+		PacketSize:            32000,
+		InsecureIgnoreHostKey: true,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary
CodeQL flagged `go/insecure-hostkeycallback` because connections defaulted to `ssh.InsecureIgnoreHostKey()` when no host keys were configured.

This change **fails closed**:
- Callers must set `HostPublicKey` / `HostPublicKeys`, **or**
- Explicitly set `InsecureIgnoreHostKey: true` (tests / trusted networks only)

### Breaking change
Clients that previously relied on the insecure default must either configure host keys (recommended) or opt into `InsecureIgnoreHostKey`.

## Alert addressed
- https://github.com/moov-io/go-sftp/security/code-scanning/1

## Test plan
- [x] `go test -short ./...`
- [ ] Full integration tests with docker-compose SFTP (`make check`)
- [ ] CI CodeQL on this PR