### PR TITLE
ci: skip code owners on go.mod/go.sum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
 * @adamdecaf @atonks2
+
+# Lockfiles have no owners so dependency-only PRs skip code-owner review.
+go.mod
+go.sum
+**/go.mod
+**/go.sum


### PR DESCRIPTION
Keep the catch-all CODEOWNERS entry. `go.mod` / `go.sum` are left without owners (last-match-wins) so lockfile-only PRs do not request a code-owner review.

Grouped Renovate "update all" PRs that also touch Actions/Dockerfiles are handled by a ruleset bypass for the Renovate GitHub App.